### PR TITLE
rename probes headings, add .tab file to zip output

### DIFF
--- a/ProbeMakerEnv_python3.yml
+++ b/ProbeMakerEnv_python3.yml
@@ -6,3 +6,4 @@ channels:
 dependencies:
   - hisat2=2.2.1
   - python=3.7
+  - seqkit=0.14.0

--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Typically, you will want to specify: <default values>
 
 After a successful workflow execution, a zipped file will appear in `RNAFISHProbeDesigner/UPLOAD_HERE\results` directory, containing the following output files:
 * `.fa` file with sequences of the probes that passed through all filters
+* `.tab` table of probes that passed through all filters, format convenient for oligos ordering
 * `.fa` file wih reverse complementary sequences of probes
 * `.bam` and `.bam.bai` alignment files of probes against genome for endogenous sequences, or `.doc` alignment file of probes against target RNA sequence for exogenous sequences
 * `.txt` file with melting temperatures of the final probes

--- a/helperScripts/customBed2Fasta.py
+++ b/helperScripts/customBed2Fasta.py
@@ -6,7 +6,7 @@ scriptName = "customBed2Fasta"
 Version = 1.2
 
 
-def bed_to_fasta(file, out):
+def bed_to_fasta(file, out, header):
     """Convert .bed file to .fasta file.
 
     Loops over the rows of input bed file to extract the sequence
@@ -15,7 +15,7 @@ def bed_to_fasta(file, out):
     df = pandas.read_csv(
         str(file), sep="\t", header=None, names=["chr", "pos1", "pos2", "seq", "Tm"]
     )
-    probe_inx = [">probe_%s_%s" % (str(i), str(out)) for i in range(1, len(df) + 1)]
+    probe_inx = [">p%s_%s" % (str(i), str(header)) for i in range(1, len(df) + 1)]
 
     new_inx = pandas.Series(probe_inx)
     out_df = pandas.concat([new_inx, df["seq"]], axis=1, sort=False)
@@ -42,6 +42,9 @@ def _parse_args():
     parser.add_argument(
         "-o", "--out", required=True, help="Output fasta file name. [required]"
     )
+    parser.add_argument(
+        "--header", required=True, help="Header base for the probes. [required]"
+    )
     args = parser.parse_args()
     return args
 
@@ -51,9 +54,10 @@ def main():
     args = _parse_args()
     inFile = args.File
     outSuffix = args.out
+    header = args.header
 
     # Call bed_to_fasta to extract sequences
-    bed_to_fasta(inFile, outSuffix)
+    bed_to_fasta(inFile, outSuffix, header)
 
 
 if __name__ == "__main__":

--- a/nextflow.config
+++ b/nextflow.config
@@ -3,9 +3,9 @@
 
 process {
 	withName: "createJellyfishIndex|blockParse|filteringEndo|filteringExo|checkStrand|kmerFilter|structureCheck|bed2fasta|bed2fastq|sam2bam|sortBam|sortIndexBam|revComplement|probeTm|alignExo" {
-		conda = "PATH/TO/ENV/ProbeMakerEnv_python2"
+		conda = "/home/ewa/anaconda3/envs/ProbeMakerEnv_python2"
 	}
-	withName: "createHisat2index|initial_mapping|mappingFinalProbes" {
-		conda = "PATH/TO/ENV/ProbeMakerEnv_python3"
+	withName: "createHisat2index|initial_mapping|mappingFinalProbes|fasta2tab" {
+		conda = "/home/ewa/anaconda3/envs/ProbeMakerEnv_python3"
 	}
 }


### PR DESCRIPTION
changing the headers of the probes in the fasta files to make them shorter, also added an oligo-ordering-friendly .tab file with final probes sequences to the results zip