### PR TITLE
add back proper conda env path name

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -3,9 +3,9 @@
 
 process {
 	withName: "createJellyfishIndex|blockParse|filteringEndo|filteringExo|checkStrand|kmerFilter|structureCheck|bed2fasta|bed2fastq|sam2bam|sortBam|sortIndexBam|revComplement|probeTm|alignExo" {
-		conda = "/home/ewa/anaconda3/envs/ProbeMakerEnv_python2"
+		conda = "PATH/TO/ENV/ProbeMakerEnv_python2"
 	}
 	withName: "createHisat2index|initial_mapping|mappingFinalProbes|fasta2tab" {
-		conda = "/home/ewa/anaconda3/envs/ProbeMakerEnv_python3"
+		conda = "PATH/TO/ENV/ProbeMakerEnv_python3"
 	}
 }


### PR DESCRIPTION
Path was incorrectly replaced. Only with "PATH/TO/ENV/" is install.sh able to replace the placeholder with the proper path.